### PR TITLE
Remove grouping bottleneck

### DIFF
--- a/src/workflows/run_benchmark/config.vsh.yaml
+++ b/src/workflows/run_benchmark/config.vsh.yaml
@@ -42,13 +42,6 @@ argument_groups:
         required: true
         direction: output
         default: task_info.yaml
-  - name: Clustering
-    arguments:
-      - name: "--resolutions"
-        type: double
-        multiple: true
-        default: [0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
-        description: Resolution parameter for clustering
   - name: Method filtering
     description: |
       Use these arguments to filter methods by name. By default, all methods are

--- a/src/workflows/run_benchmark/config.vsh.yaml
+++ b/src/workflows/run_benchmark/config.vsh.yaml
@@ -42,6 +42,13 @@ argument_groups:
         required: true
         direction: output
         default: task_info.yaml
+  - name: Clustering
+    arguments:
+      - name: "--resolutions"
+        type: double
+        multiple: true
+        default: [0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+        description: Resolution parameter for clustering
   - name: Method filtering
     description: |
       Use these arguments to filter methods by name. By default, all methods are

--- a/src/workflows/run_benchmark/main.nf
+++ b/src/workflows/run_benchmark/main.nf
@@ -148,7 +148,8 @@ workflow run_wf {
       fromState: [
         input_integrated: "method_output",
         input_dataset: "input_dataset",
-        expected_method_types: "method_types"
+        expected_method_types: "method_types",
+        resolutions: "resolutions"
       ],
       toState: { id, output, state ->
         // Add method types to the state


### PR DESCRIPTION
## Describe your changes

<!-- Describe your changes  -->

Remove a bottleneck in the benchmark workflow caused by grouping clustering results that prevented metrics from running until all methods were complete

## Checklist before requesting a review
- [ ] I have performed a self-review of my code

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [x] Bug fixes

- [ ] Proposed changes are described in the CHANGELOG.md

- [ ] CI Tests succeed and look good!