### PR TITLE
Patch: Update image version for openproblems/base_* images

### DIFF
--- a/src/control_methods/embed_cell_types/config.vsh.yaml
+++ b/src/control_methods/embed_cell_types/config.vsh.yaml
@@ -13,7 +13,7 @@ resources:
   - path: /src/control_methods/utils.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/control_methods/embed_cell_types_jittered/config.vsh.yaml
+++ b/src/control_methods/embed_cell_types_jittered/config.vsh.yaml
@@ -19,7 +19,7 @@ resources:
   - path: /src/control_methods/utils.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/control_methods/no_integration/config.vsh.yaml
+++ b/src/control_methods/no_integration/config.vsh.yaml
@@ -12,7 +12,7 @@ resources:
   - path: /src/utils/read_anndata_partial.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/control_methods/no_integration_batch/config.vsh.yaml
+++ b/src/control_methods/no_integration_batch/config.vsh.yaml
@@ -12,7 +12,7 @@ resources:
   - path: /src/utils/read_anndata_partial.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/control_methods/shuffle_integration/config.vsh.yaml
+++ b/src/control_methods/shuffle_integration/config.vsh.yaml
@@ -12,7 +12,7 @@ resources:
   - path: /src/control_methods/utils.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/control_methods/shuffle_integration_by_batch/config.vsh.yaml
+++ b/src/control_methods/shuffle_integration_by_batch/config.vsh.yaml
@@ -12,7 +12,7 @@ resources:
   - path: /src/control_methods/utils.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/control_methods/shuffle_integration_by_cell_type/config.vsh.yaml
+++ b/src/control_methods/shuffle_integration_by_cell_type/config.vsh.yaml
@@ -12,7 +12,7 @@ resources:
   - path: /src/control_methods/utils.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/data_processors/precompute_clustering_merge/config.vsh.yaml
+++ b/src/data_processors/precompute_clustering_merge/config.vsh.yaml
@@ -22,7 +22,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/data_processors/precompute_clustering_run/config.vsh.yaml
+++ b/src/data_processors/precompute_clustering_run/config.vsh.yaml
@@ -21,7 +21,7 @@ resources:
   - path: /src/utils/read_anndata_partial.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi:

--- a/src/data_processors/process_dataset/config.vsh.yaml
+++ b/src/data_processors/process_dataset/config.vsh.yaml
@@ -7,7 +7,7 @@ resources:
   - path: /common/helper_functions/subset_h5ad_by_format.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi:

--- a/src/data_processors/transform/config.vsh.yaml
+++ b/src/data_processors/transform/config.vsh.yaml
@@ -39,7 +39,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi: scanpy

--- a/src/methods/batchelor_fastmnn/config.vsh.yaml
+++ b/src/methods/batchelor_fastmnn/config.vsh.yaml
@@ -27,7 +27,7 @@ resources:
     path: script.R
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         bioc: batchelor

--- a/src/methods/batchelor_mnn_correct/config.vsh.yaml
+++ b/src/methods/batchelor_mnn_correct/config.vsh.yaml
@@ -21,7 +21,7 @@ resources:
     path: script.R
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         bioc:

--- a/src/methods/bbknn/config.vsh.yaml
+++ b/src/methods/bbknn/config.vsh.yaml
@@ -39,7 +39,7 @@ resources:
   - path: /src/utils/read_anndata_partial.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi:

--- a/src/methods/combat/config.vsh.yaml
+++ b/src/methods/combat/config.vsh.yaml
@@ -28,7 +28,7 @@ resources:
   - path: /src/utils/read_anndata_partial.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 runners:
   - type: executable
   - type: nextflow

--- a/src/methods/geneformer/config.vsh.yaml
+++ b/src/methods/geneformer/config.vsh.yaml
@@ -48,7 +48,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_pytorch_nvidia:1.0.0
+    image: openproblems/base_pytorch_nvidia:1
     setup:
       - type: python
         pip:

--- a/src/methods/harmony/config.vsh.yaml
+++ b/src/methods/harmony/config.vsh.yaml
@@ -21,7 +21,7 @@ resources:
     path: script.R
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         cran:

--- a/src/methods/harmonypy/config.vsh.yaml
+++ b/src/methods/harmonypy/config.vsh.yaml
@@ -22,7 +22,7 @@ resources:
   - path: /src/utils/read_anndata_partial.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi:

--- a/src/methods/liger/config.vsh.yaml
+++ b/src/methods/liger/config.vsh.yaml
@@ -20,7 +20,7 @@ resources:
     path: script.R
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: apt
         packages: cmake

--- a/src/methods/pyliger/config.vsh.yaml
+++ b/src/methods/pyliger/config.vsh.yaml
@@ -26,7 +26,7 @@ resources:
   - path: /src/utils/read_anndata_partial.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi:

--- a/src/methods/scalex/config.vsh.yaml
+++ b/src/methods/scalex/config.vsh.yaml
@@ -23,7 +23,7 @@ resources:
   - path: /src/utils/read_anndata_partial.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi:

--- a/src/methods/scanorama/config.vsh.yaml
+++ b/src/methods/scanorama/config.vsh.yaml
@@ -25,7 +25,7 @@ resources:
   - path: /src/utils/read_anndata_partial.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi:

--- a/src/methods/scanvi/config.vsh.yaml
+++ b/src/methods/scanvi/config.vsh.yaml
@@ -45,7 +45,7 @@ resources:
   - path: /src/utils/read_anndata_partial.py
 engines:
   - type: docker
-    image: openproblems/base_pytorch_nvidia:1.0.0
+    image: openproblems/base_pytorch_nvidia:1
     setup:
       - type: python
         pypi:

--- a/src/methods/scgpt_finetuned/config.vsh.yaml
+++ b/src/methods/scgpt_finetuned/config.vsh.yaml
@@ -48,7 +48,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_pytorch_nvidia:1.0.0
+    image: openproblems/base_pytorch_nvidia:1
     # TODO: Try to find working installation of flash attention (flash-attn<1.0.5)
     setup:
       - type: python

--- a/src/methods/scgpt_zeroshot/config.vsh.yaml
+++ b/src/methods/scgpt_zeroshot/config.vsh.yaml
@@ -50,7 +50,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_pytorch_nvidia:1.0.0
+    image: openproblems/base_pytorch_nvidia:1
     # TODO: Try to find working installation of flash attention (flash-attn<1.0.5)
     setup:
       - type: python

--- a/src/methods/scimilarity/config.vsh.yaml
+++ b/src/methods/scimilarity/config.vsh.yaml
@@ -24,7 +24,7 @@ resources:
   - path: /src/utils/exit_codes.py
 engines:
   - type: docker
-    image: openproblems/base_pytorch_nvidia:1.0.0
+    image: openproblems/base_pytorch_nvidia:1
     setup:
       - type: python
         github: Genentech/scimilarity

--- a/src/methods/scprint/config.vsh.yaml
+++ b/src/methods/scprint/config.vsh.yaml
@@ -71,7 +71,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_pytorch_nvidia:1.0.0
+    image: openproblems/base_pytorch_nvidia:1
     setup:
       - type: python
         pip:

--- a/src/methods/scvi/config.vsh.yaml
+++ b/src/methods/scvi/config.vsh.yaml
@@ -41,7 +41,7 @@ resources:
   - path: /src/utils/read_anndata_partial.py
 engines:
   - type: docker
-    image: openproblems/base_pytorch_nvidia:1.0.0
+    image: openproblems/base_pytorch_nvidia:1
     setup:
       - type: python
         pypi:

--- a/src/methods/uce/config.vsh.yaml
+++ b/src/methods/uce/config.vsh.yaml
@@ -32,7 +32,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_pytorch_nvidia:1.0.0
+    image: openproblems/base_pytorch_nvidia:1
     setup:
       - type: python
         pypi:

--- a/src/metrics/asw_batch/config.vsh.yaml
+++ b/src/metrics/asw_batch/config.vsh.yaml
@@ -41,7 +41,7 @@ resources:
   - path: /src/utils/read_anndata_partial.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi:

--- a/src/metrics/asw_label/config.vsh.yaml
+++ b/src/metrics/asw_label/config.vsh.yaml
@@ -29,7 +29,7 @@ resources:
   - path: /src/utils/read_anndata_partial.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi:

--- a/src/metrics/cell_cycle_conservation/config.vsh.yaml
+++ b/src/metrics/cell_cycle_conservation/config.vsh.yaml
@@ -39,7 +39,7 @@ resources:
   - path: /src/utils/read_anndata_partial.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi:

--- a/src/metrics/clustering_overlap/config.vsh.yaml
+++ b/src/metrics/clustering_overlap/config.vsh.yaml
@@ -61,7 +61,7 @@ resources:
   - path: /src/utils/read_anndata_partial.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi:

--- a/src/metrics/graph_connectivity/config.vsh.yaml
+++ b/src/metrics/graph_connectivity/config.vsh.yaml
@@ -38,7 +38,7 @@ resources:
   - path: /src/utils/read_anndata_partial.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi:

--- a/src/metrics/hvg_overlap/config.vsh.yaml
+++ b/src/metrics/hvg_overlap/config.vsh.yaml
@@ -37,7 +37,7 @@ resources:
   - path: /src/utils/read_anndata_partial.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi:

--- a/src/metrics/isolated_label_asw/config.vsh.yaml
+++ b/src/metrics/isolated_label_asw/config.vsh.yaml
@@ -30,7 +30,7 @@ resources:
   - path: /src/utils/read_anndata_partial.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi:

--- a/src/metrics/isolated_label_f1/config.vsh.yaml
+++ b/src/metrics/isolated_label_f1/config.vsh.yaml
@@ -49,7 +49,7 @@ resources:
   - path: /src/utils/read_anndata_partial.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi:

--- a/src/metrics/kbet/config.vsh.yaml
+++ b/src/metrics/kbet/config.vsh.yaml
@@ -44,7 +44,7 @@ resources:
   - path: /src/utils/read_anndata_partial.py
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         github: theislab/kBET

--- a/src/metrics/kbet_pg/config.vsh.yaml
+++ b/src/metrics/kbet_pg/config.vsh.yaml
@@ -34,7 +34,7 @@ resources:
   - path: /src/utils/read_anndata_partial.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi:

--- a/src/metrics/kbet_pg_label/config.vsh.yaml
+++ b/src/metrics/kbet_pg_label/config.vsh.yaml
@@ -34,7 +34,7 @@ resources:
   - path: /src/utils/read_anndata_partial.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi:

--- a/src/metrics/lisi/config.vsh.yaml
+++ b/src/metrics/lisi/config.vsh.yaml
@@ -49,7 +49,7 @@ resources:
   - path: /src/utils/read_anndata_partial.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi:

--- a/src/metrics/pcr/config.vsh.yaml
+++ b/src/metrics/pcr/config.vsh.yaml
@@ -35,7 +35,7 @@ resources:
   - path: /src/utils/read_anndata_partial.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi:


### PR DESCRIPTION
This PR updates the image version from :1.0.0 to :1 for `openproblems/base_*` images.